### PR TITLE
Deduplicate overlapping Prisma enums

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,12 +10,6 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-enum BugSeverity {
-  LOW    @map("low")
-  MEDIUM @map("medium")
-  HIGH   @map("high")
-}
-
 enum BugStatus {
   OPEN        @map("open")
   IN_PROGRESS @map("in_progress")
@@ -27,13 +21,6 @@ enum ChatType {
   MEMBER_TO_MEMBER       @map("member_to_member")
   MEMBER_TO_ORGANIZATION @map("member_to_organization")
   MEMBER_TO_GROUP        @map("member_to_group")
-}
-
-enum CustomerOrderStatus {
-  PENDING   @map("pending")
-  SHIPPED   @map("shipped")
-  DELIVERED @map("delivered")
-  CANCELLED @map("cancelled")
 }
 
 enum FavoriteType {
@@ -59,6 +46,7 @@ enum OrderStatus {
   PENDING   @map("pending")
   SHIPPED   @map("shipped")
   DELIVERED @map("delivered")
+  CANCELLED @map("cancelled")
 }
 
 enum PaymentMethod {
@@ -323,12 +311,6 @@ enum SocialLinkType {
   INSTAGRAM @map("instagram")
   GITHUB    @map("github")
   DISCORD   @map("discord")
-}
-
-enum UserPaymentMethodType {
-  CREDIT_CARD @map("credit_card")
-  DEBIT_CARD  @map("debit_card")
-  PAYPAL      @map("paypal")
 }
 
 enum ChatParticipantType {
@@ -896,14 +878,14 @@ model BlogTag {
 }
 
 model Bug {
-  id          String      @id @default(uuid())
+  id          String       @id @default(uuid())
   title       String
-  description String      @db.Text
-  severity    BugSeverity @default(MEDIUM)
-  status      BugStatus   @default(OPEN)
+  description String       @db.Text
+  severity    PriorityLevel @default(MEDIUM)
+  status      BugStatus    @default(OPEN)
   projectId   String
-  createdAt   DateTime    @default(now())
-  updatedAt   DateTime    @updatedAt
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
 
   project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
@@ -1099,21 +1081,21 @@ model CustomerMetadata {
 }
 
 model CustomerOrder {
-  id              String              @id @default(uuid())
+  id              String       @id @default(uuid())
   customerId      String
-  orderNumber     String              @unique
-  orderDate       DateTime            @default(now())
-  status          CustomerOrderStatus @default(PENDING)
-  items           Json                @default("[]")
-  totalAmount     Decimal             @db.Decimal(18, 2)
+  orderNumber     String       @unique
+  orderDate       DateTime     @default(now())
+  status          OrderStatus  @default(PENDING)
+  items           Json         @default("[]")
+  totalAmount     Decimal      @db.Decimal(18, 2)
   shippingAddress String
   billingAddress  String
   tenantId        String?
-  isArchived      Boolean             @default(false)
+  isArchived      Boolean      @default(false)
   deletedAt       DateTime?
-  metadata        Json                @default("{}")
-  createdAt       DateTime            @default(now())
-  updatedAt       DateTime            @updatedAt
+  metadata        Json         @default("{}")
+  createdAt       DateTime     @default(now())
+  updatedAt       DateTime     @updatedAt
 
   customer Customer @relation(fields: [customerId], references: [id], onDelete: Cascade)
   tenant   Tenant?  @relation(fields: [tenantId], references: [id], onDelete: SetNull)
@@ -1424,11 +1406,11 @@ model GroupMemberHistory {
 }
 
 model Issue {
-  id          String    @id @default(uuid())
+  id          String       @id @default(uuid())
   title       String
-  description String    @db.Text
-  status      BugStatus @default(OPEN)
-  severity    BugSeverity   @default(MEDIUM)
+  description String       @db.Text
+  status      BugStatus    @default(OPEN)
+  severity    PriorityLevel @default(MEDIUM)
   priority    PriorityLevel @default(MEDIUM)
   tenantId    String?
   reportedById String?
@@ -3501,12 +3483,12 @@ model UserPhoneNumber {
 }
 
 model UserPaymentMethod {
-  id        String                @id @default(uuid())
+  id        String        @id @default(uuid())
   userId    String
-  method    UserPaymentMethodType
-  metadata  Json                  @default("{}")
-  createdAt DateTime              @default(now())
-  updatedAt DateTime              @updatedAt
+  method    PaymentMethod
+  metadata  Json          @default("{}")
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
## Summary
- remove redundant schema enums that duplicated values across models
- extend `OrderStatus` with `CANCELLED` and reuse it for customer orders
- reuse `PriorityLevel` and `PaymentMethod` for bug severity and user payment methods respectively

## Testing
- npx prisma format *(fails: 403 Forbidden fetching prisma package)*

------
https://chatgpt.com/codex/tasks/task_e_68f98f6a38d8832c80cbaf76dd340a41