### PR TITLE
Translate root and docs to English

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,35 +1,37 @@
-## Verhaltenskodex für Mitwirkende
+## Contributor Code of Conduct
 
-### Unsere Verpflichtung
+### Our Commitment
 
-Um eine offene und einladende Umgebung zu fördern, verpflichten sich die Mitwirkenden und Wartenden des Projekts, die Teilnahme am Projekt und unserer Community zu einer belästigungsfreien Erfahrung für alle zu machen, unabhängig von Alter, Körpergröße, Behinderung, ethnischer Zugehörigkeit, Geschlechtsidentität und -ausdruck, Erfahrungslevel, Bildung, soziökonomischem Status, Nationalität, persönlichem Aussehen, Rasse, Religion oder sexueller Identität und Orientierung.
+To foster an open and welcoming environment, the contributors and maintainers pledge to make participation in the project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
-### Unsere Standards
+### Our Standards
 
-Beispiele für Verhaltensweisen, die dazu beitragen, eine positive Umgebung zu schaffen:
+Examples of behavior that contributes to creating a positive environment include:
 
-- Verwendung von einladender und inklusiver Sprache
-- Respekt gegenüber unterschiedlichen Ansichten und Erfahrungen
-- Konstruktive Kritik höflich annehmen
-- Fokus auf das, was das Beste für die Community ist
-- Empathie gegenüber anderen Mitgliedern der Community zeigen
+- Using welcoming and inclusive language
+- Showing respect for differing viewpoints and experiences
+- Accepting constructive criticism gracefully
+- Focusing on what is best for the community
+- Showing empathy toward other community members
 
-Beispiele für inakzeptables Verhalten:
+Examples of unacceptable behavior by participants include:
 
-- Die Verwendung sexualisierter Sprache oder Bilder und unerwünschte sexuelle Aufmerksamkeit oder Annäherungen
-- Trollen, beleidigende/abwertende Kommentare und persönliche oder politische Angriffe
-- Öffentliche oder private Belästigungen
-- Veröffentlichung von privaten Informationen anderer ohne deren ausdrückliche Erlaubnis
-- Anderes Verhalten, das als unangemessen in einem professionellen Umfeld betrachtet werden kann
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct that could reasonably be considered inappropriate in a professional setting
 
-### Durchsetzung
+### Enforcement
 
-Vorfälle von missbräuchlichem, belästigendem oder anderweitig inakzeptablem Verhalten können den Projektverantwortlichen unter [tim.hauke@hauknetz.de](mailto:tim.hauke@hauknetz.de) oder per Discord (`vecto.`) gemeldet werden. Alle Beschwerden werden geprüft und untersucht und führen zu einer Antwort, die den Umständen entsprechend notwendig und angemessen erscheint. Das Projektteam verpflichtet sich, über die Berichtenden von Vorfällen die Vertraulichkeit zu wahren.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project leads at [tim.hauke@hauknetz.de](mailto:tim.hauke@hauknetz.de) or on Discord (`vecto.`). All complaints will be reviewed and investigated, resulting in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
 
-### Kollaboratives Arbeiten
+### Collaborative Work
 
-NodCord setzt auf eine enge Zusammenarbeit zwischen API-, Bot- und Datenbank-Teams. Bitte respektiere die vereinbarten Review-Prozesse für TypeScript-Code, Prisma-Schemata und MySQL-Migrationen, um konsistente Ergebnisse zu gewährleisten.
+NodCord relies on close collaboration between the API, bot, and database teams. Please respect the agreed review processes for TypeScript code, Prisma schemas, and MySQL migrations to ensure consistent results.
 
 ### Attribution
 
-Dieser Verhaltenskodex basiert auf dem [Contributor Covenant][homepage], Version 1.4, verfügbar unter http://contributor-covenant.org/version/1/4
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at http://contributor-covenant.org/version/1/4
+
+[homepage]: http://contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,45 +1,45 @@
-# Beiträge zu NodCord
+# Contributing to NodCord
 
-Vielen Dank, dass du zur Weiterentwicklung von NodCord beitragen möchtest! Dieses Dokument erläutert die wichtigsten Abläufe für Beiträge zu unserer TypeScript-/Prisma-Codebasis.
+Thank you for your interest in improving NodCord! This document explains the most important workflows for contributing to our TypeScript/Prisma codebase.
 
-## Grundprinzipien
+## Core Principles
 
-- **TypeScript zuerst**: Neue Module und Änderungen werden in TypeScript umgesetzt. Nutze die strengen Compiler-Optionen (`noImplicitOverride`, `noUncheckedIndexedAccess`, …) und teile gemeinsame Typen in `src/types/`.
-- **Prisma + MySQL**: Datenzugriffe erfolgen über den Prisma Client. Direkte MySQL-Abfragen oder Mongoose-Modelle sollten vermieden bzw. schrittweise ersetzt werden.
-- **Getrennte Verantwortlichkeiten**: API, Bot und Client teilen sich Services. Achte darauf, Logik wiederverwendbar zu kapseln, statt sie zu duplizieren.
+- **TypeScript first:** New modules and changes are implemented in TypeScript. Enable strict compiler options (`noImplicitOverride`, `noUncheckedIndexedAccess`, …) and share common types through `src/types/`.
+- **Prisma + MySQL:** Use the Prisma Client for all database access. Avoid direct MySQL queries or Mongoose models; replace them gradually where they still exist.
+- **Separation of concerns:** API, bot, and client share services. Encapsulate reusable logic instead of duplicating it.
 
-## Entwicklungsablauf
+## Development Workflow
 
-1. **Issue wählen oder erstellen**: Beschreibe kurz das Problem bzw. Feature und markiere, ob Prisma-Schemaänderungen notwendig sind.
-2. **Branch erstellen**: `git checkout -b feature/mein-thema`
-3. **Umgebung vorbereiten**:
+1. **Choose or open an issue:** Describe the problem or feature briefly and note whether Prisma schema changes are required.
+2. **Create a branch:** `git checkout -b feature/my-topic`
+3. **Prepare the environment:**
    - `npm install`
    - `npx prisma generate`
-   - Lokale MySQL-Datenbank bereitstellen und `.env` mit `DATABASE_URL` befüllen
-4. **Code anpassen**:
-   - TypeScript-Dateien mit eindeutigen Interfaces erstellen.
-   - Bei Schemaänderungen `prisma migrate dev --name mein_migrationsname` ausführen.
-   - Seeds in `prisma/seed.ts` oder `src/seeds/` aktualisieren.
-5. **Tests & Checks**:
-   - `npm run lint && npm run typecheck` (stilistische und statische Analyse)
-   - `npm run build` (stellt sicher, dass der TypeScript-Compiler fehlerfrei durchläuft)
-   - `npm test` oder gezielt `npm run test:api|bot|views` (abhängig vom betroffenen Bereich)
-   - `npm run test:coverage` bei Änderungen an Kernlogik oder Services
-   - `npm run prisma:migrate` gegen eine Testdatenbank, falls Migrationen hinzugefügt wurden.
-6. **Pull Request eröffnen**:
-   - Fasse Änderungen, Migrationsschritte und neue Env-Variablen zusammen.
-   - Verweise auf relevante Dokumente im `docs/`-Ordner (z. B. aktualisierte Architektur- oder Installationsguides).
+   - Provide a local MySQL database and populate `.env` with `DATABASE_URL`
+4. **Implement your changes:**
+   - Create TypeScript files with clear interfaces.
+   - For schema changes run `prisma migrate dev --name my_migration_name`.
+   - Update seeds in `prisma/seed.ts` or `src/seeds/`.
+5. **Run tests and checks:**
+   - `npm run lint && npm run typecheck` (style and static analysis)
+   - `npm run build` (ensures the TypeScript compiler passes)
+   - `npm test` or a focused run via `npm run test:api|bot|views`
+   - `npm run test:coverage` for changes to core logic or services
+   - `npm run prisma:migrate` against a test database when adding migrations
+6. **Open a pull request:**
+   - Summarize your changes, migration steps, and new environment variables.
+   - Reference relevant documents in `docs/` (e.g. updated architecture or installation guides).
 
-## Stil- & Qualitätsrichtlinien
+## Style & Quality Guidelines
 
-- Verwende Prettier (`npm run format`) für konsistente Formatierung.
-- Schreibe sprechende Commit-Nachrichten im Imperativ.
-- Dokumentiere neue Services oder Datenmodelle kurz in den passenden Dateien unter `docs/reference/` oder `docs/overview/`.
+- Use Prettier (`npm run format`) for consistent formatting.
+- Write descriptive commit messages in the imperative.
+- Document new services or data models in the relevant files under `docs/reference/` or `docs/overview/`.
 
-## Sicherheit & Datenschutz
+## Security & Privacy
 
-Solltest du sicherheitsrelevante Probleme finden, melde sie bitte vertraulich wie in [SECURITY.md](./SECURITY.md) beschrieben. Lege keine Secrets oder produktiven Datenbankverbindungen in Pull Requests offen.
+If you find a security issue, report it confidentially as described in [SECURITY.md](./SECURITY.md). Never expose secrets or production database connections in pull requests.
 
-## Fragen
+## Questions
 
-Wenn du unsicher bist, kontaktiere das Maintainer-Team per E-Mail an [tim.hauke@hauknetz.de](mailto:tim.hauke@hauknetz.de) oder über Discord (`vecto.`). Wir unterstützen dich gerne bei der Umsetzung deiner Idee!
+If you are unsure about anything, reach out to the maintainer team via [tim.hauke@hauknetz.de](mailto:tim.hauke@hauknetz.de) or Discord (`vecto.`). We are happy to support you!

--- a/README.md
+++ b/README.md
@@ -2,82 +2,83 @@
 
 ![NodCord Logo with Text](https://github.com/user-attachments/assets/f13e96c2-4dff-48f9-8da0-c2acfd49c09b)
 
-NodCord ist eine in **TypeScript** geschriebene Service-Plattform rund um Discord-Automatisierung. Die REST-API basiert auf Express.js, der integrierte Bot nutzt discord.js und sämtliche Persistenz erfolgt über **Prisma** mit einer MySQL-Datenbank. Ziel ist eine einheitliche Codebasis, die API, Bot und begleitende Tools auf denselben Datenquellen aufbaut.
+NodCord is a **TypeScript** service platform for Discord automation. The REST API is powered by Express.js, the integrated bot uses discord.js, and all persistence is handled through **Prisma** with a MySQL database. The goal is to provide a unified codebase so that the API, bot, and supporting tools all operate on the same data sources.
 
-> 💡 Die Anwendung befindet sich in einer laufenden Migration von älteren JavaScript-/Mongoose-Komponenten. Neue Beiträge sollten sich am beschriebenen TypeScript/Prisma-Stack orientieren.
+> 💡 The application is currently migrating from older JavaScript/Mongoose components. New contributions should follow the TypeScript/Prisma stack described here.
 
-## Inhaltsverzeichnis
+## Table of Contents
 
 - [Features](#features)
-- [Technologien](#technologien)
+- [Technologies](#technologies)
 - [Installation](#installation)
-- [Verwendung](#verwendung)
-- [Datenbank & Prisma](#datenbank--prisma)
-- [Konfiguration](#konfiguration)
-- [Dokumentation](#dokumentation)
+- [Usage](#usage)
+- [Testing & Quality Assurance](#testing--quality-assurance)
+- [Database & Prisma](#database--prisma)
+- [Configuration](#configuration)
+- [Documentation](#documentation)
 - [Contributing](#contributing)
-- [Sicherheit](#sicherheit)
-- [Lizenz](#lizenz)
+- [Security](#security)
+- [License](#license)
 
 ## Features
 
-- REST-API mit TypeScript-Controller-Layer und klaren Response-Typen
-- Discord Bot mit gemeinsam genutzten Services und Datenbankzugriff über Prisma
-- MySQL als zentrale Datenquelle (lokal via Docker oder gehostete Instanz)
-- Modularer Aufbau (API, Bot, Client, Seeds, Scripts) für einfache Erweiterungen
-- Ausführliche Projekt- und Migrationsdokumentation im `docs/` Verzeichnis
-- Enterprise-fähige Testaufteilung (API, Bot und EJS-Views) inklusive Coverage-Reports und JUnit-Ausgabe
+- REST API with a TypeScript controller layer and strongly typed responses
+- Discord bot that shares services and database access through Prisma
+- MySQL as the central data source (run locally via Docker or use a hosted instance)
+- Modular structure (API, bot, client, seeds, scripts) for easy extensions
+- Extensive project and migration documentation inside the `docs/` directory
+- Enterprise-ready test layout (API, bot, and EJS views) including coverage reports and JUnit output
 
-## Technologien
+## Technologies
 
-| Bereich         | Stack                                                                 |
+| Area            | Stack                                                                 |
 | --------------- | --------------------------------------------------------------------- |
-| Laufzeit        | Node.js ≥ 18                                                           |
-| Sprache         | TypeScript (strict mode)                                              |
-| Framework       | Express.js                                                             |
-| Datenbank       | MySQL 8.x oder kompatibel (MariaDB ≥ 10.6 getestet)                    |
+| Runtime         | Node.js ≥ 18                                                          |
+| Language        | TypeScript (strict mode)                                             |
+| Framework       | Express.js                                                            |
+| Database        | MySQL 8.x or compatible (MariaDB ≥ 10.6 verified)                     |
 | ORM/Client      | Prisma                                                                |
-| Discord         | discord.js                                                             |
+| Discord         | discord.js                                                            |
 | Tooling         | ts-node-dev, Jest (multi-project), Supertest, Testing Library, Prettier, Prisma CLI |
 
 ## Installation
 
-### Voraussetzungen
+### Requirements
 
-- Node.js **>= 18** und npm **>= 9**
-- Laufende MySQL-Instanz (z. B. Docker: `docker run --name nodcord-mysql -e MYSQL_ROOT_PASSWORD=secret -p 3306:3306 -d mysql:8`)
+- Node.js **>= 18** and npm **>= 9**
+- Running MySQL instance (e.g. Docker: `docker run --name nodcord-mysql -e MYSQL_ROOT_PASSWORD=secret -p 3306:3306 -d mysql:8`)
 - Git
 
-### Schritte
+### Steps
 
-1. Repository klonen:
+1. Clone the repository:
    ```bash
-   git clone https://github.com/deinbenutzername/NodCord.git
+   git clone https://github.com/vectode/NodCord.git
    ```
-2. Projektverzeichnis betreten:
+2. Enter the project directory:
    ```bash
    cd NodCord
    ```
-3. Abhängigkeiten installieren:
+3. Install dependencies:
    ```bash
    npm install
    ```
-4. Prisma Client generieren (erstellt `node_modules/@prisma/client` anhand des Schemas):
+4. Generate the Prisma Client (creates `node_modules/@prisma/client` based on the schema):
    ```bash
    npx prisma generate
    ```
-5. Erste Migration gegen die MySQL-Datenbank ausführen:
+5. Run the initial migration against your MySQL database:
    ```bash
    npx prisma migrate deploy
    ```
-6. Entwicklungsserver starten:
+6. Start the development server:
    ```bash
    npm run dev
    ```
 
-## Verwendung
+## Usage
 
-Die wichtigsten npm-Skripte:
+Key npm scripts:
 
 ```json
 {
@@ -95,73 +96,73 @@ Die wichtigsten npm-Skripte:
 }
 ```
 
-- `npm run dev` startet den Server mit Hot-Reloading (ts-node-dev).
-- `npm run build` erzeugt ein `dist/` Verzeichnis mit kompilierter JS-Ausgabe.
-- `npm start` führt den Build im Produktionsmodus aus.
-- `npm test` führt alle Jest-Projekte (API, Bot, Views) gemeinsam aus.
-- `npm run test:api|bot|views` ermöglicht fokussierte Testläufe pro Verantwortungsbereich.
-- `npm run test:coverage` erzeugt kombinierte Coverage-Reports (`text`, `lcov`, `cobertura`).
-- `npm run test:ci` verkettet Linting, Type-Checking und Coverage für CI/CD-Pipelines.
-- `npm run prisma:migrate` deployt Migrationen in die konfigurierte Datenbank.
-- `npm run prisma:studio` öffnet die Prisma Oberfläche zur Dateninspektion.
+- `npm run dev` starts the server with hot reloading (ts-node-dev).
+- `npm run build` creates a `dist/` directory with compiled JS output.
+- `npm start` launches the build in production mode.
+- `npm test` executes all Jest projects (API, bot, views) together.
+- `npm run test:api|bot|views` enables focused test runs per responsibility.
+- `npm run test:coverage` produces combined coverage reports (`text`, `lcov`, `cobertura`).
+- `npm run test:ci` chains linting, type checking, and coverage for CI/CD pipelines.
+- `npm run prisma:migrate` deploys migrations to the configured database.
+- `npm run prisma:studio` opens the Prisma Studio UI for data inspection.
 
-## Testen & Qualitätssicherung
+## Testing & Quality Assurance
 
-Die Testlandschaft basiert auf einer Jest-Multi-Projekt-Konfiguration:
+The test landscape is based on a Jest multi-project configuration:
 
-- **API**: Läuft im Node-Test-Environment und nutzt `supertest`/`nock`, um REST-Endpunkte und externe Integrationen zu prüfen.
-- **Bot**: Nutzt das Node-Environment, sodass Discord-spezifische Services isoliert via Mocks getestet werden können.
-- **Views**: Läuft im `jsdom`-Environment und bindet `@testing-library/jest-dom`, um EJS-Templates und clientnahe Logik zu verifizieren.
+- **API**: Runs in the Node test environment and uses `supertest`/`nock` to validate REST endpoints and external integrations.
+- **Bot**: Uses the Node environment so Discord-specific services can be tested in isolation through mocks.
+- **Views**: Runs in the `jsdom` environment and relies on `@testing-library/jest-dom` to verify EJS templates and client-adjacent logic.
 
-Alle Projekte teilen sich `jest.setup.ts`, in dem `jest-extended` aktiviert und die Test-Laufzeitumgebung vereinheitlicht wird. Ergebnisse werden zusätzlich als JUnit-Datei unter `reports/junit/jest-junit.xml` abgelegt und die Coverage landet gesammelt im Ordner `coverage/`.
+All projects share `jest.setup.ts`, which enables `jest-extended` and unifies the runtime environment. Test results are also exported as a JUnit file at `reports/junit/jest-junit.xml`, and coverage reports are collected inside `coverage/`.
 
-> 💡 Über `npm run test:watch -- --selectProjects api` lässt sich jeder Bereich auch im Watch-Modus starten.
+> 💡 Run `npm run test:watch -- --selectProjects api` to start any area in watch mode.
 
-## Datenbank & Prisma
+## Database & Prisma
 
-Das Prisma Schema befindet sich unter [`prisma/schema.prisma`](./prisma/schema.prisma). Es definiert alle Models (z. B. Benutzer, Rollen, Projekte) und beschreibt Relationen sowie Constraints für MySQL. Weitere Hinweise:
+The Prisma schema lives at [`prisma/schema.prisma`](./prisma/schema.prisma). It defines all models (e.g. users, roles, projects) and describes relations plus constraints for MySQL. Additional tips:
 
-- Lege eine `.env`-Datei im Projektstamm an und definiere darin `DATABASE_URL`, z. B. `mysql://user:password@localhost:3306/nodcord`.
-- Verwende `npx prisma db push`, wenn du das Schema während der Entwicklung schnell synchronisieren möchtest.
-- Seeds werden über `prisma db seed` ausgeführt und greifen auf die Dateien in `src/seeds/` zurück.
+- Create a `.env` file at the project root and define `DATABASE_URL`, e.g. `mysql://user:password@localhost:3306/nodcord`.
+- Use `npx prisma db push` when you want to sync the schema quickly during development.
+- Run seeds through `prisma db seed`; they rely on files inside `src/seeds/`.
 
-## Konfiguration
+## Configuration
 
-1. Lege eine neue Datei `.env` im Projektstamm an (oder befülle die von deinem Secrets-Management-System ausgerollte Variante).
-2. Trage alle benötigten Variablen aus den folgenden Kategorien ein:
-   - **Core Runtime:** `VERSION`, `NODE_ENV`, `SERVER_NAME`, `LOG_LEVEL`, `TZ`
+1. Create a `.env` file in the project root (or populate the version provided by your secrets management system).
+2. Provide the variables required from the following categories:
+   - **Core runtime:** `VERSION`, `NODE_ENV`, `SERVER_NAME`, `LOG_LEVEL`, `TZ`
    - **Server & API:** `PORT`, `BASE_URL`, `API_HTTPS`, `API_BASE_URL`, `API_PORT`
-   - **Datenbanken:** `DATABASE_URL`, `MONGO_URI`
-   - **Security & Monitoring:** `SESSION_SECRET`, `JWT_SECRET`, `JWT_SESSION_SECRET`, `SENTRY_AUTH_TOKEN`
-   - **Client-Routing:** `CLIENT_HTTPS`, `CLIENT_BASE_URL`, `CLIENT_PORT`
-   - **Discord & Bot:** `DISCORD_*`, `BOT_ACTIVITY_*`, `OWNER_ID`
+   - **Databases:** `DATABASE_URL`, `MONGO_URI`
+   - **Security & monitoring:** `SESSION_SECRET`, `JWT_SECRET`, `JWT_SESSION_SECRET`, `SENTRY_AUTH_TOKEN`
+   - **Client routing:** `CLIENT_HTTPS`, `CLIENT_BASE_URL`, `CLIENT_PORT`
+   - **Discord & bot:** `DISCORD_*`, `BOT_ACTIVITY_*`, `OWNER_ID`
    - **OAuth:** `GOOGLE_*`, `GITHUB_*`, `LINKEDIN_*`
    - **Payments:** `STRIPE_SECRET_KEY`, `PAYPAL_CLIENT_*`
-   - **Mail & Kontakt:** `SMTP_*`, `CONTACT_EMAIL`, `CONTACT_SMTP_*`
-   - **Infrastruktur:** `TS_*`
+   - **Mail & contact:** `SMTP_*`, `CONTACT_EMAIL`, `CONTACT_SMTP_*`
+   - **Infrastructure:** `TS_*`
 
-Weitere Erläuterungen findest du in den Modul-spezifischen Dateien unter `src/config/` sowie in den Referenzdokumenten im Ordner `docs/`.
+Further explanations live in the module-specific files under `src/config/` and in the reference documentation under `docs/`.
 
-## Dokumentation
+## Documentation
 
-Ausführliche Architekturhinweise, Installationsanleitungen, Roadmaps und Prozessbeschreibungen befinden sich im Ordner [`docs/`](./docs). Wichtige Einstiegspunkte:
+Detailed architecture notes, installation guides, roadmaps, and process descriptions live inside [`docs/`](./docs). Key entry points:
 
-- [`docs/guides/`](./docs/guides) – Installations-, FAQ- und Support-Anleitungen
-- [`docs/overview/`](./docs/overview) – Architektur, Komponenten und Datenflüsse
-- [`docs/planning/`](./docs/planning) – Migrationsfahrpläne Richtung vollständiger Prisma-Nutzung
-- [`docs/reference/`](./docs/reference) – Technische Referenzen und Arbeitsabläufe
-- [`docs/process/`](./docs/process) – Contributing-, Release- und Change-Management
+- [`docs/guides/`](./docs/guides) – Installation, FAQ, and support guides
+- [`docs/overview/`](./docs/overview) – Architecture, components, and data flows
+- [`docs/planning/`](./docs/planning) – Migration plans toward full Prisma adoption
+- [`docs/reference/`](./docs/reference) – Technical references and workflows
+- [`docs/process/`](./docs/process) – Contributing, release, and change management
 
 ## Contributing
 
-Beiträge sind willkommen! Lies bitte die [CONTRIBUTING.md](./CONTRIBUTING.md), bevor du Pull Requests öffnest. Dort findest du Informationen zu Branch-Strategie, Coding-Guidelines für TypeScript sowie zum Umgang mit Prisma Migrationen.
+Contributions are welcome! Please read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening pull requests. It covers the branch strategy, TypeScript coding guidelines, and how to manage Prisma migrations.
 
-## Sicherheit
+## Security
 
-Sicherheitsrelevante Hinweise findest du in der [SECURITY.md](./SECURITY.md). Melde Schwachstellen vertraulich, damit wir die MySQL-/Prisma-Infrastruktur schnell absichern können.
+Security-relevant information can be found in [SECURITY.md](./SECURITY.md). Report vulnerabilities confidentially so that we can secure the MySQL/Prisma infrastructure quickly.
 
-## Lizenz
+## License
 
-Dieses Projekt ist unter der MIT-Lizenz lizenziert. Siehe die [LICENSE](./LICENSE)-Datei für weitere Details.
+This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for details.
 
 ![NodCord Logo](https://imgur.com/dCl3Q6H.png)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,12 @@
-## Sicherheitsrichtlinien
+## Security Policy
 
-Danke, dass du dabei hilfst, NodCord sicher zu halten! Bitte folge diesen Schritten, wenn du eine Sicherheitslücke findest oder sensible Daten entdeckst:
+Thank you for helping keep NodCord secure! Please follow these steps when you discover a vulnerability or sensitive data:
 
-1. Melde den Fund vertraulich per E-Mail an [security@nodcord.dev](mailto:security@nodcord.dev) oder direkt an [tim.hauke@hauknetz.de](mailto:tim.hauke@hauknetz.de).
-2. Beschreibe das Problem so detailliert wie möglich (betroffene Endpunkte, erwartetes Verhalten, tatsächliches Verhalten, Schritte zur Reproduktion).
-3. Teile, falls vorhanden, Logs oder Screenshots ausschließlich über verschlüsselte Kanäle. Bitte veröffentliche keine Proof-of-Concepts, bevor wir reagieren konnten.
-4. Gib uns mindestens 14 Tage Zeit, um auf deinen Report zu reagieren und einen Fix für Prisma-Modelle, MySQL-Migrationen oder API-Code bereitzustellen.
+1. Report the finding confidentially via email to [security@nodcord.dev](mailto:security@nodcord.dev) or directly to [tim.hauke@hauknetz.de](mailto:tim.hauke@hauknetz.de).
+2. Describe the issue as precisely as possible (affected endpoints, expected behavior, actual behavior, steps to reproduce).
+3. Share logs or screenshots only over encrypted channels if necessary. Please do not publish proof-of-concepts before we have responded.
+4. Allow us at least 14 days to respond and prepare fixes for Prisma models, MySQL migrations, or API code.
 
-Wir priorisieren Sicherheitsmeldungen, die Datenintegrität oder Authentifizierung betreffen. Nach Abschluss informieren wir dich gerne über die ergriffenen Maßnahmen und nennen dich – falls gewünscht – in den Release Notes.
+We prioritize security reports that affect data integrity or authentication. After remediation we are happy to inform you about the actions taken and credit you in the release notes if you wish.
 
-Vielen Dank für deine Unterstützung!
+Thank you for your support!

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -1,35 +1,35 @@
 # FAQ
 
-## Häufig gestellte Fragen
+## Frequently Asked Questions
 
-### Wie erhalte ich meinen Discord Bot Token?
+### How do I get my Discord bot token?
 
-1. Gehe zum [Discord Developer Portal](https://discord.com/developers/applications).
-2. Erstelle eine neue Anwendung oder wähle eine bestehende aus.
-3. Gehe zum Bot-Tab und erstelle einen neuen Bot.
-4. Kopiere den Token deines Bots und füge ihn in deine `.env`-Datei als `DISCORD_TOKEN` ein.
+1. Visit the [Discord Developer Portal](https://discord.com/developers/applications).
+2. Create a new application or select an existing one.
+3. Open the **Bot** tab and create a bot user.
+4. Copy the bot token and add it to your `.env` file as `DISCORD_TOKEN`.
 
-### Wie verbinde ich NodCord mit meiner MySQL-Datenbank?
+### How do I connect NodCord to my MySQL database?
 
-- Lege eine Datenbank an, z. B. `nodcord`.
-- Trage die Zugangsdaten in deiner `.env`-Datei als `DATABASE_URL` ein, z. B. `mysql://user:pass@localhost:3306/nodcord`.
-- Führe `npx prisma migrate deploy` aus, um das Schema zu installieren.
-- Starte den Server mit `npm run dev`.
+- Create a database, e.g. `nodcord`.
+- Add the credentials to your `.env` file as `DATABASE_URL`, for example `mysql://user:pass@localhost:3306/nodcord`.
+- Run `npx prisma migrate deploy` to install the schema.
+- Start the server with `npm run dev`.
 
-### Der Bot reagiert nicht auf Befehle. Was kann ich tun?
+### The bot does not respond to commands. What can I do?
 
-- Überprüfe, ob `DISCORD_TOKEN`, `DISCORD_CLIENT_ID` und `DISCORD_GUILD_ID` korrekt gesetzt sind.
-- Stelle sicher, dass der Bot die richtigen Berechtigungen auf dem Server hat.
-- Prüfe die Logs des Bots/Servers. Prisma-Fehler deuten häufig auf eine fehlende Migration oder falsche Datenbank-URL hin.
+- Verify that `DISCORD_TOKEN`, `DISCORD_CLIENT_ID`, and `DISCORD_GUILD_ID` are set correctly.
+- Make sure the bot has the required permissions on the server.
+- Check the server/bot logs. Prisma errors often indicate a missing migration or an incorrect database URL.
 
-### Prisma meldet einen Fehler beim Generieren oder Migrieren. Wie gehe ich vor?
+### Prisma reports an error while generating or migrating. What should I do?
 
-- Kontrolliere, ob MySQL läuft und der Benutzer die nötigen Rechte besitzt.
-- Lösche keine Migrationen manuell – verwende `prisma migrate dev --name <beschreibung>` für neue Änderungen.
-- Für lokale Tests kann `npx prisma db push` helfen, das Schema schnell zu synchronisieren.
+- Confirm that MySQL is running and that the user has the necessary privileges.
+- Do not delete migrations manually—use `prisma migrate dev --name <description>` for new changes.
+- For local testing, `npx prisma db push` can help synchronize the schema quickly.
 
-### Wo finde ich weitere Hilfe?
+### Where can I get additional help?
 
-- Sieh dir den [Support-Guide](./support.md) an.
-- Öffne ein Issue auf GitHub, wenn du einen Bug vermutest.
-- Kontaktiere das Maintainer-Team per E-Mail (siehe SECURITY.md) oder über Discord (`vecto.`).
+- Read the [support guide](./support.md).
+- Open an issue on GitHub if you suspect a bug.
+- Contact the maintainer team via email (see SECURITY.md) or on Discord (`vecto.`).

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -1,44 +1,44 @@
 ## Installation
 
-Diese Anleitung führt dich durch die Installation von NodCord auf Basis von TypeScript, Prisma und MySQL.
+This guide walks you through installing NodCord with TypeScript, Prisma, and MySQL.
 
-### Voraussetzungen
+### Requirements
 
-- Node.js (Version 18 oder höher)
-- npm (Version 9 oder höher)
-- MySQL 8.x oder kompatibel (z. B. MariaDB ≥ 10.6)
+- Node.js (version 18 or higher)
+- npm (version 9 or higher)
+- MySQL 8.x or compatible (e.g. MariaDB ≥ 10.6)
 - Git
 
-### Schritte
+### Steps
 
-1. Repository klonen:
+1. Clone the repository:
    ```sh
-   git clone https://github.com/deinbenutzername/NodCord.git
+   git clone https://github.com/vectode/NodCord.git
    ```
 
-2. In das Projektverzeichnis wechseln:
+2. Switch into the project directory:
    ```sh
    cd NodCord
    ```
 
-3. Abhängigkeiten installieren:
+3. Install dependencies:
    ```sh
    npm install
    ```
 
-4. Prisma Client generieren und Migrationen anwenden:
+4. Generate the Prisma Client and apply migrations:
    ```sh
    npx prisma generate
    npx prisma migrate deploy
    ```
 
-5. Konfigurationsdatei vorbereiten:
-   - Lege eine `.env`-Datei an (z. B. per `touch .env` oder durch Ausrollen über dein Secret-Management).
-   - Trage die benötigten Variablen ein. Die wichtigsten Blöcke findest du im Abschnitt „Server & API“, „Datenbanken“, „Sicherheit“, „Discord & Bot“, „OAuth & Payments“, „E-Mail“ und „Infrastruktur“ der README.
+5. Prepare the configuration file:
+   - Create a `.env` file (e.g. via `touch .env` or by rolling it out through your secrets management).
+   - Populate the required variables. The key sections are listed in the README under “Server & API,” “Databases,” “Security,” “Discord & Bot,” “OAuth & Payments,” “Email,” and “Infrastructure.”
 
-6. Entwicklungsserver starten:
+6. Start the development server:
    ```sh
    npm run dev
    ```
 
-Der Server läuft anschließend unter `http://localhost:3000`. Für Produktionsumgebungen führe zuvor `npm run build` aus und starte anschließend mit `npm start`.
+The server will be available at `http://localhost:3000`. For production environments, run `npm run build` first and then launch `npm start`.

--- a/docs/guides/support.md
+++ b/docs/guides/support.md
@@ -1,24 +1,21 @@
 # SUPPORT
 
-## Unterstützung
+## Getting Help
 
-Wenn du Hilfe zu NodCord benötigst, gibt es mehrere Möglichkeiten, Unterstützung zu erhalten:
+If you need assistance with NodCord, there are several ways to get support:
 
-### Dokumentation
+### Documentation
 
-Lies die ausführliche [Projekt-Dokumentation](../reference/documentation.md) für detaillierte Anweisungen zur Installation, Konfiguration und Nutzung des Projekts.
+Review the detailed [project documentation](../reference/documentation.md) for instructions on installing, configuring, and using the project.
 
 ### GitHub Issues
 
-Wenn du ein Problem hast, das nicht durch die Dokumentation abgedeckt ist, öffne bitte ein Issue auf GitHub:
-[NodCord Issues](https://github.com/vectode/NodCord/issues)
+If you encounter a problem that is not covered by the documentation, please open an issue on GitHub: [NodCord Issues](https://github.com/vectode/NodCord/issues)
 
 ### Community
 
-Tritt unserer Community auf Discord bei, um Hilfe von anderen Benutzern und Entwicklern zu erhalten:
-[Discord-Einladung (auf Anfrage)](mailto:tim.hauke@hauknetz.de?subject=NodCord%20Discord%20Invite)
+Join our community on Discord to receive help from other users and developers: [Discord invite (on request)](mailto:tim.hauke@hauknetz.de?subject=NodCord%20Discord%20Invite)
 
-### E-Mail Support
+### Email Support
 
-Du kannst auch direkt per E-Mail Unterstützung erhalten:
-[security@nodcord.dev](mailto:security@nodcord.dev) oder [tim.hauke@hauknetz.de](mailto:tim.hauke@hauknetz.de)
+You can also reach out directly via email: [security@nodcord.dev](mailto:security@nodcord.dev) or [tim.hauke@hauknetz.de](mailto:tim.hauke@hauknetz.de)

--- a/docs/meta/folder-structure.md
+++ b/docs/meta/folder-structure.md
@@ -1,6 +1,6 @@
-# Ordnerstruktur
+# Folder Structure
 
-Die folgende Übersicht zeigt die wichtigsten Ordner und Dateien im Projekt und beschreibt ihre Aufgaben. Sie dient als Einstieg, um schnell die relevanten Bereiche zu finden.
+The following overview highlights the most important directories and files in the project and explains their purpose. Use it to quickly locate relevant areas.
 
 ```text
 NodCord/
@@ -9,31 +9,31 @@ NodCord/
 ├── LICENSE
 ├── README.md
 ├── SECURITY.md
-├── docs/                   # Dokumentation, Leitfäden und Planungsunterlagen
-│   ├── guides/             # Schritt-für-Schritt-Anleitungen (Installation, FAQ, Support)
-│   ├── meta/               # Meta-Dokumente wie diese Strukturübersicht
-│   ├── overview/           # Architektur- und High-Level-Übersichten
-│   ├── planning/           # Roadmaps, Aufgabenlisten und detaillierte Migrationspläne
-│   ├── process/            # Projektprozesse (Changelog, Release-Plan, Contribution-Richtlinien)
-│   └── reference/          # Technische Referenzen und tiefere Beschreibungen
-├── nodemon.json            # Dev-Server-Konfiguration für ts-node-dev
-├── package.json            # Projektabhängigkeiten und Skripte
-├── prisma/                 # Prisma-Schema, Migrationen und Seeds
-│   └── schema.prisma       # MySQL-Modelldefinitionen
-├── tsconfig.json           # TypeScript-Compiler-Einstellungen
-├── dist/                   # Kompilierte Ausgabedateien (wird beim Build erstellt)
-└── src/                    # Anwendungscode (API, Bot, Client, Seeds etc.)
-    ├── api/                # Express-App, Controller, Routen, Middlewares, Helper & Services
-    ├── bot/                # Discord-Bot mit Commands, Events und Utility-Funktionen
-    ├── client/             # Frontend-Code/Assets für das Dashboard
-    ├── config/             # Konfigurationsdateien für API, Bot und Server
-    ├── database/           # Verbindungslogik und Datenbank-spezifische Hilfen
-    ├── models/             # Übergangsweise vorhandene Mongoose-Modelle (werden durch Prisma ersetzt)
-    ├── public/             # Statische Assets (CSS, Bilder, hochgeladene Dateien)
-    ├── scripts/            # Automatisierungs- und Wartungsskripte
-    ├── seeds/              # Seed-Daten und Initialisierungsskripte
-    ├── server.ts           # Einstiegspunkt für den Serverstart
-    └── views/              # EJS-Templates für serverseitiges Rendering
+├── docs/                   # Documentation, guides, and planning material
+│   ├── guides/             # Step-by-step guides (installation, FAQ, support)
+│   ├── meta/               # Meta documents such as this structure overview
+│   ├── overview/           # Architecture and high-level descriptions
+│   ├── planning/           # Roadmaps, task lists, and detailed migration plans
+│   ├── process/            # Project processes (changelog, release plan, contribution guidelines)
+│   └── reference/          # Technical references and deeper explanations
+├── nodemon.json            # Dev server configuration for ts-node-dev
+├── package.json            # Project dependencies and scripts
+├── prisma/                 # Prisma schema, migrations, and seeds
+│   └── schema.prisma       # MySQL model definitions
+├── tsconfig.json           # TypeScript compiler settings
+├── dist/                   # Compiled output (created during builds)
+└── src/                    # Application code (API, bot, client, seeds, etc.)
+    ├── api/                # Express app, controllers, routes, middleware, helpers & services
+    ├── bot/                # Discord bot with commands, events, and utilities
+    ├── client/             # Frontend code/assets for the dashboard
+    ├── config/             # Configuration files for API, bot, and server
+    ├── database/           # Connection logic and database-specific helpers
+    ├── models/             # Transitional Mongoose models (being replaced by Prisma)
+    ├── public/             # Static assets (CSS, images, uploaded files)
+    ├── scripts/            # Automation and maintenance scripts
+    ├── seeds/              # Seed data and initialization scripts
+    ├── server.ts           # Entry point for starting the server
+    └── views/              # EJS templates for server-side rendering
 ```
 
-> **Hinweis:** Der Fokus aktueller Arbeiten liegt auf der Konsolidierung des TypeScript-Codes und der Migration von MongoDB/Mongoose zu Prisma + MySQL. Änderungen am `src/`-Bereich sollten eng mit dem Maintainer-Team abgestimmt werden.
+> **Note:** Current work focuses on consolidating the TypeScript code and migrating from MongoDB/Mongoose to Prisma + MySQL. Coordinate changes in the `src/` area closely with the maintainer team.

--- a/docs/overview/architecture.md
+++ b/docs/overview/architecture.md
@@ -1,35 +1,35 @@
-## Architektur von NodCord
+## NodCord Architecture
 
-Diese Datei beschreibt die Architektur von NodCord und erklärt die wichtigsten Komponenten und deren Interaktionen. Die Plattform setzt vollständig auf TypeScript und nutzt Prisma als ORM für eine MySQL-Datenbank.
+This document outlines the architecture of NodCord and explains the most important components and how they interact. The platform is built entirely with TypeScript and uses Prisma as the ORM for a MySQL database.
 
-### Hauptkomponenten
+### Core Components
 
-- **Express Server**: Behandelt HTTP-Anfragen und dient als API-Endpunkt. Eingänge werden in `src/api` typisiert verarbeitet.
-- **Discord Bot**: Läuft parallel zum API-Server, nutzt die gleichen Services und Prisma-Repositories für Datenzugriffe.
-- **Prisma Layer**: Zentraler Datenzugriff über `prisma/schema.prisma` und generierten Prisma Client. Ersetzt nach und nach ältere Mongoose-Modelle.
-- **Service-Schicht**: Enthält Geschäftslogik, orchestriert API, Bot und externe Integrationen (z. B. OAuth, Zahlungsdienste).
+- **Express server:** Handles HTTP requests and exposes the API endpoints. Requests are processed with strong typing inside `src/api`.
+- **Discord bot:** Runs alongside the API server and relies on the same services and Prisma repositories for data access.
+- **Prisma layer:** Central data access through `prisma/schema.prisma` and the generated Prisma Client. It replaces legacy Mongoose models step by step.
+- **Service layer:** Contains business logic and orchestrates API, bot, and external integrations (e.g. OAuth, payment providers).
 
-### Datenfluss
+### Data Flow
 
-1. **HTTP-Anfrage**: Ein Benutzer sendet eine Anfrage an den Express-Server.
-2. **Routing & Controller**: Die Anfrage wird an den passenden Controller geleitet, der Validierung, Autorisierung und Transformation übernimmt.
-3. **Services & Prisma**: Controller rufen Services auf, die über den Prisma Client auf MySQL zugreifen und Geschäftslogik ausführen.
-4. **Antwort**: Typisierte DTOs werden zurück an den Controller gereicht und als HTTP-Response oder Bot-Aktion ausgegeben.
+1. **HTTP request:** A user sends a request to the Express server.
+2. **Routing & controllers:** The request is forwarded to the relevant controller, which handles validation, authorization, and transformation.
+3. **Services & Prisma:** Controllers call services that use the Prisma Client to access MySQL and execute business logic.
+4. **Response:** Typed DTOs are returned to the controller and served as an HTTP response or bot action.
 
-### Discord-Bot-Interaktionen
+### Discord Bot Interactions
 
-1. Der Bot empfängt ein Event (Slash Command, Guild-Event etc.).
-2. Event-Handler greifen auf gemeinsame Services zu (z. B. Ticket-Erstellung, Projektverwaltung).
-3. Über Prisma werden dieselben Tabellen angesprochen wie in der API.
-4. Rückmeldungen gehen als Discord-Nachricht, Embed oder Follow-up an den Benutzer.
+1. The bot receives an event (slash command, guild event, etc.).
+2. Event handlers access shared services (e.g. ticket creation, project management).
+3. Prisma touches the same tables that the API uses.
+4. Feedback is sent back as a Discord message, embed, or follow-up.
 
-### Persistenz
+### Persistence
 
-- Das **Prisma Schema** definiert User-, Rollen-, Projekt- und Ticket-Strukturen als Ausgangsbasis.
-- Migrationen werden mit `npm run prisma:migrate` ausgerollt.
-- Seeds und Tests nutzen gemeinsame Helper unter `src/seeds` und `prisma`.
+- The **Prisma schema** defines the baseline structures for users, roles, projects, and tickets.
+- Deploy migrations with `npm run prisma:migrate`.
+- Seeds and tests use shared helpers inside `src/seeds` and `prisma`.
 
-### Zukunftsaussichten
+### Outlook
 
-- Schrittweise Ablösung der verbliebenen MongoDB/Mongoose-Komponenten zugunsten von Prisma-Repositories.
-- Aufbau eines konsistenten Domain-Layers mit geteilten Typdefinitionen und Services, die sowohl der API als auch dem Bot dienen.
+- Gradually phase out remaining MongoDB/Mongoose components in favor of Prisma repositories.
+- Establish a consistent domain layer with shared type definitions and services that power both the API and the bot.

--- a/docs/planning/detailed-todo.md
+++ b/docs/planning/detailed-todo.md
@@ -1,61 +1,61 @@
-# NodCord 2.0.0 – Detailplan zur vollständigen Migration
+# NodCord 2.0.0 – Detailed Plan for the Full Migration
 
-Dieser Plan ergänzt den high-level Fahrplan in [`todo.md`](./todo.md) und beschreibt konkrete Schritte für eine produktionsreife TypeScript-/Prisma-/MySQL-Version. Jede Aufgabe ist so formuliert, dass sie nachvollziehbar getestet werden kann.
+This plan complements the high-level roadmap in [`todo.md`](./todo.md) and describes concrete steps toward a production-ready TypeScript/Prisma/MySQL release. Each task is formulated so it can be verified through testing.
 
-## 1. Tooling & Infrastruktur
+## 1. Tooling & Infrastructure
 
-- [ ] **TypeScript Tooling vereinheitlichen**: `tsconfig.json` finalisieren, gemeinsame ESLint-/Prettier-Konfiguration ergänzen, Pfad-Aliasse für `src/api`, `src/bot`, `src/client` festlegen.
-- [ ] **Dev-Server standardisieren**: `npm run dev` (ts-node-dev) als Single-Entry-Point beibehalten, Hot-Reload für API und Bot sicherstellen.
-- [ ] **Prisma Projektstruktur**: `prisma/` Ordner mit `schema.prisma`, Migrationen und optionalen Seeds pflegen; Skripte `npm run prisma:*` nutzen.
-- [ ] **Environment Management**: Zentrale `.env`-Baseline im Secrets-Management pflegen (MySQL, Redis, OAuth, Bot), Secrets-Handling dokumentieren, dotenv-Ladepunkte prüfen.
-- [ ] **CI/CD-Erweiterung**: Pipeline definieren (Build, Test, Prisma Migrate, Prisma Generate). GitHub Actions vorbereiten.
+- [ ] **Unify TypeScript tooling:** Finalize `tsconfig.json`, add shared ESLint/Prettier configuration, define path aliases for `src/api`, `src/bot`, `src/client`.
+- [ ] **Standardize the dev server:** Keep `npm run dev` (ts-node-dev) as the single entry point and ensure hot reload works for both API and bot.
+- [ ] **Prisma project structure:** Maintain the `prisma/` directory with `schema.prisma`, migrations, and optional seeds; rely on the `npm run prisma:*` scripts.
+- [ ] **Environment management:** Maintain a central `.env` baseline in secrets management (MySQL, Redis, OAuth, bot), document secret handling, review dotenv entry points.
+- [ ] **CI/CD expansion:** Define the pipeline (build, test, Prisma migrate, Prisma generate). Prepare GitHub Actions.
 
-## 2. Datenmodell & Persistenz
+## 2. Data Model & Persistence
 
-- [ ] **Prisma-Schema ausbauen**: Alle bisherigen Mongoose-Modelle (`src/models/*.ts`) nach `prisma/schema.prisma` übersetzen, inklusive Relationen, Enums und Default-Werten.
-- [ ] **Migrationsstrategie**: Für jedes Modul (Auth, Commerce, Tickets, Developer Program, Analytics, Integrationen) eigene Migrationen erstellen. Historische Datenmigration (Mongo → MySQL) planen.
-- [ ] **Prisma Client Integration**: Zentrale Instanz (`src/database/prismaClient.ts`) erstellen, in API/Bot Services injizieren, Lifecycle-Hooks (Shutdown, Error Handling) ergänzen.
-- [ ] **Repository Layer**: Abstraktionen für wiederkehrende Queries bauen (z. B. `UserRepository`, `ProjectRepository`) und gemeinsam nutzen.
-- [ ] **Seeds & Testdaten**: `prisma/seed.ts` etablieren, modulare Seeds in `src/seeds/` an Prisma anpassen, automatisierte Sample-Daten für E2E-Tests bereitstellen.
+- [ ] **Extend the Prisma schema:** Translate all remaining Mongoose models (`src/models/*.ts`) into `prisma/schema.prisma`, including relations, enums, and default values.
+- [ ] **Migration strategy:** Create dedicated migrations for each module (auth, commerce, tickets, developer program, analytics, integrations). Plan the historical data migration (Mongo → MySQL).
+- [ ] **Prisma Client integration:** Create a central instance (`src/database/prismaClient.ts`), inject it into API/bot services, and add lifecycle hooks (shutdown, error handling).
+- [ ] **Repository layer:** Build abstractions for recurring queries (e.g. `UserRepository`, `ProjectRepository`) and use them consistently.
+- [ ] **Seeds & test data:** Establish `prisma/seed.ts`, adapt modular seeds in `src/seeds/` to Prisma, and provide automated sample data for E2E tests.
 
 ## 3. API & Services
 
-### 3.1 Infrastruktur
+### 3.1 Infrastructure
 
-- [ ] `src/api/app.ts` und `src/server.ts` auf Prisma vorbereiten: Datenbank-Healthchecks, Graceful Shutdown, gemeinsame Logger.
-- [ ] Middleware-Schicht (`src/api/middlewares`) auf TypeScript-Definitionen aktualisieren, Request/User-Kontext sauber typisieren.
-- [ ] Helpers (`src/api/helpers`) für Responses, JWT, Uploads etc. auf Prisma-basierte Services umstellen.
-- [ ] Utility-Funktionen (`src/api/utils`) mit Typed Configs versehen, Dateiupload-/Auth-Flows modernisieren.
+- [ ] Prepare `src/api/app.ts` and `src/server.ts` for Prisma: database health checks, graceful shutdown, shared logger.
+- [ ] Update the middleware layer (`src/api/middlewares`) to modern TypeScript definitions and ensure the request/user context is well typed.
+- [ ] Migrate helpers (`src/api/helpers`) for responses, JWT, uploads, etc. to Prisma-backed services.
+- [ ] Provide typed configs for utility functions (`src/api/utils`) and modernize file-upload/auth flows.
 
-### 3.2 Feature-Module (Auswahl)
+### 3.2 Feature Modules (selection)
 
-Für jedes Modul gilt: Routes → Controller → Services → Prisma-Repositories → Tests.
+For each module: routes → controller → services → Prisma repositories → tests.
 
-- [ ] **Auth & User Management**: Passport-/Session-Integration auf Prisma-Usermodelle anpassen, Password-Reset & OAuth berücksichtigen.
-- [ ] **Role & Permission System**: Prisma-Relationen für Rollen/Rechte implementieren, Guard-Middlewares aktualisieren.
-- [ ] **Commerce (Products, Orders, Returns)**: Zahlungs- und Order-Logik über Prisma-Transaktionen abbilden.
-- [ ] **Content (Blog, Comments, Tags)**: Prisma-Relationen für Posts, Kommentare, Tags modellieren, Caching-Strategien prüfen.
-- [ ] **Support & Tickets**: Ticket-System an Prisma-Tabellen anbinden, Bot-Befehle synchronisieren.
-- [ ] **Integrationen (GitHub, Steam, Proxmox, CloudNet, Faceit, Teamspeak)**: Credential-Speicherung über Prisma, Secrets verschlüsseln.
-- [ ] **Analytics & Logging**: Prisma-Tabellen für Audit-Logs, Statistiken, Event-Tracking aufbauen.
+- [ ] **Auth & user management:** Adjust Passport/session integration to Prisma user models; include password reset & OAuth flows.
+- [ ] **Role & permission system:** Implement Prisma relations for roles/permissions and refresh guard middleware.
+- [ ] **Commerce (products, orders, returns):** Model payments and order logic with Prisma transactions.
+- [ ] **Content (blog, comments, tags):** Model posts, comments, and tags with Prisma relations; assess caching strategies.
+- [ ] **Support & tickets:** Connect the ticket system to Prisma tables and align bot commands.
+- [ ] **Integrations (GitHub, Steam, Proxmox, CloudNet, Faceit, Teamspeak):** Store credentials through Prisma and encrypt secrets.
+- [ ] **Analytics & logging:** Create Prisma tables for audit logs, statistics, and event tracking.
 
-## 4. Discord-Bot & Client
+## 4. Discord Bot & Client
 
-- [ ] Bot-Kommandos (`src/bot/commands`, `src/bot/events`) vollständig auf TypeScript portieren, gemeinsame Services nutzen.
-- [ ] Datenzugriffe des Bots über Prisma-Services abstrahieren (z. B. Ticket-Erstellung, User-Informationen).
-- [ ] Client/Frontend-Module (falls aktiv) auf API-Änderungen abstimmen, Shared Types verwenden.
+- [ ] Port bot commands (`src/bot/commands`, `src/bot/events`) fully to TypeScript and reuse shared services.
+- [ ] Abstract bot data access through Prisma services (e.g. ticket creation, user information).
+- [ ] Align client/frontend modules (if active) with API changes and reuse shared types.
 
-## 5. Qualitätssicherung
+## 5. Quality Assurance
 
-- [ ] **Testing**: Jest-Konfiguration aktualisieren, Integrationstests für Prisma (mit Test-DB) aufsetzen, Bot-Kommandos mit Mocks testen.
-- [ ] **Linting & Formatting**: Prettier/ESLint in CI verankern, Husky/Commit Hooks optional vorbereiten.
-- [ ] **Dokumentation**: Nach jeder größeren Änderung README, `docs/reference/`, `docs/guides/` und `docs/overview/` aktualisieren.
-- [ ] **Release Notes & Change Tracking**: `docs/process/changelog.md` pflegen, Breaking Changes klar kommunizieren.
+- [ ] **Testing:** Refresh the Jest configuration, add integration tests for Prisma (with a test database), test bot commands with mocks.
+- [ ] **Linting & formatting:** Anchor Prettier/ESLint in CI and optionally prepare Husky/commit hooks.
+- [ ] **Documentation:** After major changes update the README, `docs/reference/`, `docs/guides/`, and `docs/overview/`.
+- [ ] **Release notes & change tracking:** Maintain `docs/process/changelog.md` and communicate breaking changes clearly.
 
-## 6. Kommunikation & Organisation
+## 6. Communication & Organization
 
-- [ ] Contribution-Flow laut [`CONTRIBUTING.md`](../../CONTRIBUTING.md) anwenden, Reviews mit Fokus auf TypeScript-Typisierung und Prisma-Migration durchführen.
-- [ ] Community-Feedback über Discord/GitHub sammeln und priorisieren.
-- [ ] Security-Audits für neue Datenmodelle durchführen (siehe [`SECURITY.md`](../../SECURITY.md)).
+- [ ] Follow the contribution flow defined in [`CONTRIBUTING.md`](../../CONTRIBUTING.md); focus reviews on TypeScript typing and Prisma migrations.
+- [ ] Collect and prioritize community feedback via Discord/GitHub.
+- [ ] Run security reviews for new data models (see [`SECURITY.md`](../../SECURITY.md)).
 
-Mit diesen Schritten schaffen wir eine stabile Grundlage für NodCord 2.0.0 auf TypeScript und Prisma. Jede erledigte Checkbox sollte mit PR-Referenzen und Tests dokumentiert werden.
+These steps provide a solid foundation for NodCord 2.0.0 on TypeScript and Prisma. Each completed checkbox should be documented with PR references and tests.

--- a/docs/planning/roadmap.md
+++ b/docs/planning/roadmap.md
@@ -1,55 +1,55 @@
 # NodCord Roadmap
 
-## Übersicht
+## Overview
 
-Diese Roadmap skizziert geplante Features, Verbesserungen und Meilensteine für NodCord. Der Fokus liegt auf der Migration zu einer konsistenten TypeScript-Codebasis mit Prisma/MySQL sowie auf stabilen Bot- und API-Features.
+This roadmap outlines planned features, improvements, and milestones for NodCord. The main focus is migrating to a consistent TypeScript codebase with Prisma/MySQL and delivering stable bot and API features.
 
-## Aktueller Status
+## Current Status
 
-- **Version**: 2.0.0-alpha
-- **Schwerpunkt**: TypeScript/Prisma Infrastruktur, Kernmodule, Dokumentation
+- **Version:** 2.0.0-alpha
+- **Focus:** TypeScript/Prisma infrastructure, core modules, documentation
 
-## Meilensteine
+## Milestones
 
-### 2.0.0-alpha – Fundament schaffen
+### 2.0.0-alpha – Establish the foundation
 
-- [x] TypeScript-Build-Setup (`tsconfig.json`, `npm run build`, `npm run dev`)
-- [x] Prisma Schema initialisieren (`User`, `Role`, `Project`, `Ticket`)
-- [x] Dokumentation für Installation, Architektur, Contributing aktualisieren
-- [x] Dev-Server auf ts-node-dev/nodemon abstimmen
-- [ ] Erste Prisma-Migrationen und Seeds bereitstellen
-- [ ] Kernmodule (Auth, User, Tickets) auf Prisma-Services migrieren
+- [x] TypeScript build setup (`tsconfig.json`, `npm run build`, `npm run dev`)
+- [x] Initialize the Prisma schema (`User`, `Role`, `Project`, `Ticket`)
+- [x] Refresh documentation for installation, architecture, and contributing
+- [x] Align the dev server with ts-node-dev/nodemon
+- [ ] Provide initial Prisma migrations and seeds
+- [ ] Migrate core modules (auth, user, tickets) to Prisma services
 
-### 2.0.0-beta – Feature-Parität herstellen
+### 2.0.0-beta – Achieve feature parity
 
-- [ ] Sämtliche API-Module auf Prisma portieren (Commerce, Blog, Integrationen, Analytics)
-- [ ] Bot-Kommandos auf gemeinsame Services und Prisma-Datenzugriff umstellen
-- [ ] Integrationstests und E2E-Workflows mit Test-Datenbank etablieren
-- [ ] CI/CD-Pipeline mit Build, Test, Prisma Migrate und Sicherheitschecks veröffentlichen
+- [ ] Port all API modules to Prisma (commerce, blog, integrations, analytics)
+- [ ] Switch bot commands to shared services and Prisma data access
+- [ ] Establish integration tests and E2E workflows with a test database
+- [ ] Publish a CI/CD pipeline covering build, test, Prisma migrate, and security checks
 
-### 2.0.0 – Stable Release
+### 2.0.0 – Stable release
 
-- [ ] Prisma-Schema finalisieren, Migrationen einfrieren
-- [ ] Upgrade Guide und Migrationshinweise dokumentieren
-- [ ] Monitoring/Observability (Logging, Health Checks, Alerts) ausrollen
-- [ ] Release Notes und Changelog veröffentlichen
+- [ ] Finalize the Prisma schema and freeze migrations
+- [ ] Document upgrade guides and migration instructions
+- [ ] Roll out monitoring/observability (logging, health checks, alerts)
+- [ ] Publish release notes and the changelog
 
-## Zukünftige Pläne
+## Future Plans
 
-- [ ] Mehrmandantenfähigkeit (Organisationen/Teams mit isolierten Datenräumen)
-- [ ] Erweiterte Analytics-Module (Dashboards, Event-Tracking)
-- [ ] Erweiterbare Bot-Plugin-Schnittstellen
-- [ ] Infrastruktur-Automatisierung (Docker Compose, Helm Charts)
+- [ ] Multi-tenancy (organizations/teams with isolated workspaces)
+- [ ] Extended analytics modules (dashboards, event tracking)
+- [ ] Extensible bot plugin interfaces
+- [ ] Infrastructure automation (Docker Compose, Helm charts)
 
-## Mitwirken
+## Contribute
 
-Wir begrüßen Beiträge aus der Community! Wenn du Ideen für Features, Verbesserungen oder Fehlerbehebungen hast, eröffne bitte ein Issue oder reiche einen Pull Request ein. Sieh dir unsere [Contributing-Richtlinien](../process/contributing.md) an, bevor du beginnst.
+We welcome community contributions! If you have ideas for features, improvements, or bug fixes, please open an issue or submit a pull request. Review our [contributing guidelines](../process/contributing.md) before you get started.
 
-## Kontakt
+## Contact
 
-Für Fragen oder Vorschläge kontaktiere bitte den Projektbetreuer:
+If you have questions or suggestions, reach out to the project maintainer:
 
-- **E-Mail**: [tim.hauke@hauknetz.de](mailto:tim.hauke@hauknetz.de)
-- **Discord**: `vecto.`
+- **Email:** [tim.hauke@hauknetz.de](mailto:tim.hauke@hauknetz.de)
+- **Discord:** `vecto.`
 
-Vielen Dank für dein Interesse an NodCord! Lass uns gemeinsam etwas Großartiges aufbauen.
+Thank you for your interest in NodCord! Let’s build something great together.

--- a/docs/planning/todo.md
+++ b/docs/planning/todo.md
@@ -1,37 +1,37 @@
-# NodCord 2.0.0 – Migrationsfahrplan
+# NodCord 2.0.0 – Migration Roadmap
 
-## Zielbild
-- Vollständiger Wechsel auf TypeScript (keine `.js`-Quelldateien mehr in `src/`).
-- Datenzugriff ausschließlich über Prisma Client mit MySQL (Mongoose wird ersetzt).
-- Gemeinsame Services für API, Bot und Client.
-- Konsistente Build-/Deploy-Pipeline (`npm run build`, `npm start`, `npm run dev`).
+## Target State
+- Complete transition to TypeScript (no `.js` source files left in `src/`).
+- Database access exclusively through Prisma Client with MySQL (replacing Mongoose).
+- Shared services for API, bot, and client.
+- Consistent build/deploy pipeline (`npm run build`, `npm start`, `npm run dev`).
 
-## Phase 0 – Analyse & Vorbereitung
-- [ ] Bestandsaufnahme aller Module (`src/api`, `src/bot`, `src/client`, `src/models`, `src/database`, `src/seeds`).
-- [ ] Abhängigkeiten prüfen (`package.json`): veraltete Pakete markieren, Prisma/TypeScript-Setup finalisieren.
-- [ ] Datenbank-Mapping vorbereiten: Mongoose-Schemas den Prisma-Modellen im `prisma/schema.prisma` gegenüberstellen.
-- [ ] Secrets-Quelle für MySQL, Redis, Discord, OAuth und externe Integrationen pflegen (z. B. zentrale `.env`-Vorlage im Secret-Manager).
+## Phase 0 – Analysis & preparation
+- [ ] Assess all modules (`src/api`, `src/bot`, `src/client`, `src/models`, `src/database`, `src/seeds`).
+- [ ] Review dependencies (`package.json`): mark outdated packages and finalize the Prisma/TypeScript setup.
+- [ ] Prepare database mapping: align Mongoose schemas with Prisma models in `prisma/schema.prisma`.
+- [ ] Maintain the secrets source for MySQL, Redis, Discord, OAuth, and external integrations (e.g. a central `.env` template in secrets management).
 
-## Phase 1 – Alpha (Grundfunktionalität lauffähig)
-- [ ] TypeScript-Konfiguration und ts-node-dev Setup abschließen (`npm run dev`).
-- [ ] Prisma Client in `src/server.ts` und zentralen Services verwenden.
-- [ ] Auth, User, Roles, Tickets und Kernmodule auf Prisma portieren.
-- [ ] Seeds auf Prisma umstellen (`prisma db seed`).
-- [ ] Basis-Dokumentation aktualisieren (README, Installationsanleitung, Architektur).
+## Phase 1 – Alpha (core functionality running)
+- [ ] Finalize TypeScript configuration and the ts-node-dev setup (`npm run dev`).
+- [ ] Use the Prisma Client inside `src/server.ts` and central services.
+- [ ] Port auth, user, roles, tickets, and other core modules to Prisma.
+- [ ] Migrate seeds to Prisma (`prisma db seed`).
+- [ ] Update baseline documentation (README, installation guide, architecture).
 
-## Phase 2 – Beta (Feature-Parität & Stabilität)
-- [ ] Alle verbleibenden Module (Commerce, Blog, Integrationen, Analytics) auf Prisma migrieren.
-- [ ] Integrationstests und Bot-Kommandos mit Prisma-Datenanbindung validieren.
-- [ ] CI/CD-Pipeline mit Build, Test, Prisma-Migrationen und Linting aufsetzen.
-- [ ] Performance- und Sicherheitsprüfungen durchführen (Indexe, Rate-Limits, Secrets Management).
+## Phase 2 – Beta (feature parity & stability)
+- [ ] Migrate all remaining modules (commerce, blog, integrations, analytics) to Prisma.
+- [ ] Validate integration tests and bot commands with Prisma-backed data access.
+- [ ] Implement a CI/CD pipeline that covers build, test, Prisma migrations, and linting.
+- [ ] Run performance and security checks (indexes, rate limits, secrets management).
 
-## Phase 3 – LTS (Härtung & Release)
-- [ ] Finales Review aller Prisma-Modelle und Migrationen.
-- [ ] Release-Plan (Versionierung, Changelog, Upgrade Guide) fertigstellen.
-- [ ] Monitoring, Observability und Backups für MySQL/Prisma etablieren.
-- [ ] LTS-Support-Prozess definieren (Bugfix-Policy, Wartungsfenster).
+## Phase 3 – LTS (hardening & release)
+- [ ] Final review of all Prisma models and migrations.
+- [ ] Finalize the release plan (versioning, changelog, upgrade guide).
+- [ ] Establish monitoring, observability, and backups for MySQL/Prisma.
+- [ ] Define the LTS support process (bugfix policy, maintenance windows).
 
-## Laufende Aufgaben
-- [ ] Coding-Guidelines pflegen (`CONTRIBUTING.md`, `docs/process/contributing.md`).
-- [ ] Dokumentation mit jeder größeren Änderung aktualisieren.
-- [ ] Feedback aus Community/Issue-Tracker regelmäßig einarbeiten.
+## Ongoing tasks
+- [ ] Maintain coding guidelines (`CONTRIBUTING.md`, `docs/process/contributing.md`).
+- [ ] Update documentation with each major change.
+- [ ] Incorporate community/issue tracker feedback regularly.

--- a/docs/process/changelog.md
+++ b/docs/process/changelog.md
@@ -1,27 +1,27 @@
 # CHANGELOG
 
-Alle bemerkenswerten Änderungen an diesem Projekt werden in dieser Datei dokumentiert.
+All notable changes to this project will be documented in this file.
 
-Das Format basiert auf [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
 ## [2.0.0-alpha] - 2025-10-22
-### Hinzugefügt
-- Prisma Schema (`prisma/schema.prisma`) mit Kernmodellen für User, Rollen, Projekte und Tickets.
-- Überarbeitete Dokumentation (README, Installationsguide, Architekturübersicht, Contributing).
-- Neue Projektleitfäden zu TypeScript/Prisma in `docs/planning` und `docs/process`.
-- Nodemon-/TypeScript-Konfiguration für `npm run dev` und neue npm-Skripte (Prisma, Build, Formatierung).
+### Added
+- Prisma schema (`prisma/schema.prisma`) with core models for users, roles, projects, and tickets.
+- Updated documentation (README, installation guide, architecture overview, contributing).
+- New project guides for TypeScript/Prisma inside `docs/planning` and `docs/process`.
+- Nodemon/TypeScript configuration for `npm run dev` and new npm scripts (Prisma, build, formatting).
 
-### Entfernt
-- Legacy `build.js` Skript und veraltete Build-Hinweise.
+### Removed
+- Legacy `build.js` script and outdated build notes.
 
 ## [1.0.1] - 2024-08-01
-### Geändert
-- Aktualisierte Dokumentation
+### Changed
+- Updated documentation
 
 ## [1.0.0] - 2024-07-28
-### Hinzugefügt
-- Initiale Version von NodCord
-- Grundlegende API-Endpunkte
-- Discord Bot mit `!ping` und `!info` Befehlen
+### Added
+- Initial version of NodCord
+- Core API endpoints
+- Discord bot with `!ping` and `!info` commands

--- a/docs/process/contributing.md
+++ b/docs/process/contributing.md
@@ -1,36 +1,36 @@
-## Beitragende willkommen!
+## Welcome, Contributors!
 
-Vielen Dank für dein Interesse, zu NodCord beizutragen! Dieser Leitfaden fasst die wichtigsten Regeln für Beiträge zur TypeScript-/Prisma-Codebasis zusammen.
+Thank you for your interest in contributing to NodCord! This guide summarizes the key rules for working with the TypeScript/Prisma codebase.
 
-## Wie du beitragen kannst
+## Ways to Contribute
 
-- **Fehler melden**: Öffne ein Issue und beschreibe das Problem, inklusive Steps, Logs und Prisma-Migration (falls relevant).
-- **Funktionen vorschlagen**: Skizziere das gewünschte Verhalten und die betroffenen Module (API, Bot, Prisma-Schema).
-- **Code beisteuern**: Erstelle einen Fork, entwickle in einem Feature-Branch und öffne einen Pull Request.
+- **Report bugs:** Open an issue that describes the problem, including reproduction steps, logs, and Prisma migration context when relevant.
+- **Propose features:** Outline the desired behavior and the affected modules (API, bot, Prisma schema).
+- **Submit code:** Fork the repository, develop on a feature branch, and open a pull request.
 
-## Code-Richtlinien
+## Coding Guidelines
 
-- Schreibe ausschließlich TypeScript-Dateien (`.ts`/`.tsx`).
-- Nutze Prisma Client für Datenzugriffe. Direkte MySQL-Queries nur in begründeten Ausnahmefällen.
-- Teile gemeinsame Typen in `src/types/` und Services im passenden Modul (`src/api/services`, `src/bot/services`).
-- Achte auf saubere Fehlerrückgaben und Logging, insbesondere bei Datenbankoperationen.
+- Write TypeScript files only (`.ts`/`.tsx`).
+- Use the Prisma Client for database access. Direct MySQL queries are reserved for exceptional cases.
+- Share common types under `src/types/` and services inside the corresponding module (`src/api/services`, `src/bot/services`).
+- Handle errors and logging carefully, especially around database operations.
 
-## Pull-Request-Prozess
+## Pull Request Process
 
-1. Branch erstellen: `git checkout -b feature/mein-feature`
-2. Änderungen durchführen und bei Schema-Anpassungen `prisma migrate dev --name <name>` ausführen.
-3. Tests und Checks laufen lassen:
+1. Create a branch: `git checkout -b feature/my-feature`
+2. Implement your changes and run `prisma migrate dev --name <name>` when you touch the schema.
+3. Execute tests and checks:
    ```bash
    npm run build
    npm test
    npm run prisma:migrate
    ```
-4. Dokumentation aktualisieren (README, docs/…), falls sich Abläufe ändern.
-5. Pull Request erstellen und folgende Punkte dokumentieren:
-   - Zusammenfassung der Änderung
-   - Auswirkungen auf Prisma-Schema/Migrationen
-   - Hinweise auf neue Env-Variablen oder Konfigurationsschritte
+4. Update documentation (README, docs/…) whenever workflows change.
+5. Open a pull request and document the following:
+   - Summary of the change
+   - Impact on the Prisma schema/migrations
+   - Notes about new environment variables or configuration steps
 
-## Danke!
+## Thank You!
 
-Wir freuen uns über jede Unterstützung. Bei Fragen wende dich an [tim.hauke@hauknetz.de](mailto:tim.hauke@hauknetz.de) oder per Discord an `vecto.`.
+We appreciate every contribution. If you have questions, contact [tim.hauke@hauknetz.de](mailto:tim.hauke@hauknetz.de) or reach out on Discord (`vecto.`).

--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -1,36 +1,36 @@
-## Release Prozess
+## Release Process
 
-Dieser Leitfaden beschreibt den Prozess zur Erstellung eines neuen Releases von NodCord.
+This guide describes how to create a new release of NodCord.
 
-### Schritte
+### Steps
 
-1. **Version aktualisieren**
-   - Aktualisiere die Version in der `package.json`.
-   - Ergänze den Eintrag im `docs/process/changelog.md` mit Versionsnummer und Datum.
+1. **Update the version**
+   - Bump the version inside `package.json`.
+   - Add an entry with version number and date to `docs/process/changelog.md`.
 
-2. **Prisma prüfen**
-   - Stelle sicher, dass alle Migrationen committed sind (`prisma/migrations`).
-   - Führe `npm run prisma:migrate` gegen eine frische MySQL-Instanz aus.
-   - Generiere den Prisma Client neu (`npm run prisma:generate`).
+2. **Verify Prisma**
+   - Ensure all migrations are committed (`prisma/migrations`).
+   - Run `npm run prisma:migrate` against a fresh MySQL instance.
+   - Regenerate the Prisma Client (`npm run prisma:generate`).
 
-3. **Tests & Builds**
+3. **Tests & builds**
    - `npm run build`
    - `npm test`
-   - Optional: Smoke-Tests gegen eine Staging-Umgebung durchführen.
+   - Optionally run smoke tests against a staging environment.
 
-4. **Code einfrieren**
-   - Keine neuen Features mehr, nur kritische Fixes.
-   - Prüfe offene Pull Requests und Issues.
+4. **Code freeze**
+   - Block new features; only critical fixes are allowed.
+   - Review open pull requests and issues.
 
-5. **Release erstellen**
-   - Tag auf GitHub setzen (`git tag vX.Y.Z && git push origin vX.Y.Z`).
-   - Release Notes aus dem Changelog übernehmen.
+5. **Create the release**
+   - Tag the release on GitHub (`git tag vX.Y.Z && git push origin vX.Y.Z`).
+   - Copy the release notes from the changelog.
 
-6. **Veröffentlichen**
-   - Merge des Release-Branches in `main`.
-   - Prisma Migrationen auf Produktion ausführen.
-   - Monitoring und Alerts aktivieren.
+6. **Publish**
+   - Merge the release branch into `main`.
+   - Run Prisma migrations in production.
+   - Enable monitoring and alerts.
 
-7. **Nachbereitung**
-   - Release in der Roadmap markieren.
-   - Feedback aus der Community sammeln.
+7. **Follow-up**
+   - Highlight the release on the roadmap.
+   - Gather feedback from the community.

--- a/docs/reference/documentation.md
+++ b/docs/reference/documentation.md
@@ -1,103 +1,103 @@
 # NodCord Documentation
 
-## Einführung
+## Introduction
 
-NodCord ist eine Express-basierte API mit integriertem Discord-Bot, geschrieben in TypeScript. Die Persistenz erfolgt über Prisma gegen eine MySQL-Datenbank. Dieses Dokument fasst die wichtigsten Arbeitsabläufe, Werkzeuge und Projektstrukturen zusammen.
+NodCord is an Express-based API with an integrated Discord bot written in TypeScript. Data persistence is handled through Prisma on top of a MySQL database. This document summarizes the key workflows, tooling, and project structure.
 
 ## Installation & Setup
 
-### Voraussetzungen
+### Requirements
 
-- Node.js >= 18 (LTS empfohlen)
+- Node.js >= 18 (LTS recommended)
 - npm >= 9
-- Zugriff auf eine MySQL 8.x oder kompatible Instanz
-- Optional: Redis für Sessions/Caching
+- Access to a MySQL 8.x or compatible instance
+- Optional: Redis for sessions/caching
 
-### Setup-Schritte
+### Setup Steps
 
-1. Repository klonen:
+1. Clone the repository:
    ```bash
    git clone https://github.com/vectode/NodCord.git
    cd NodCord
    ```
-2. Abhängigkeiten installieren:
+2. Install dependencies:
    ```bash
    npm install
    ```
-3. Prisma vorbereiten:
+3. Prepare Prisma:
    ```bash
    npx prisma generate
    npx prisma migrate deploy
    ```
-4. Eine `.env`-Datei anlegen (z. B. über dein Secrets-Management-System) und dort die MySQL-/Discord-Zugangsdaten eintragen (siehe README).
+4. Create a `.env` file (e.g. via your secrets management system) and add the MySQL/Discord credentials (see the README).
 
-## Entwicklungs- und Betriebs-Workflows
+## Development & Operations Workflows
 
-### Server starten
+### Starting the server
 
-- Entwicklung mit automatischem Reload:
+- Development with automatic reload:
   ```bash
   npm run dev
   ```
-- Produktion nach Build (lädt kompilierten Code aus `dist/`):
+- Production after building (runs compiled code from `dist/`):
   ```bash
   npm run build
   npm start
   ```
 
-### Prisma & Datenbank
+### Prisma & Database
 
-- Migrationen deployen:
+- Deploy migrations:
   ```bash
   npm run prisma:migrate
   ```
-- Prisma Client neu generieren (bei Schemaänderungen):
+- Regenerate the Prisma Client (after schema changes):
   ```bash
   npm run prisma:generate
   ```
-- Prisma Studio öffnen:
+- Open Prisma Studio:
   ```bash
   npm run prisma:studio
   ```
 
-### Tests & Code-Stil
+### Tests & Code Style
 
-- Automatisierte Tests (Jest):
+- Automated tests (Jest):
   ```bash
   npm test
   ```
-- Formatierung prüfen bzw. anwenden:
+- Check or apply formatting:
   ```bash
   npm run lint
   npm run format
   ```
 
-## API-Referenz (Kurzüberblick)
+## API Reference (short overview)
 
-Die Controller und Routen liegen unter `src/api`. Häufig genutzte Endpunkte:
+Controllers and routes live under `src/api`. Frequently used endpoints include:
 
-- `GET /api/discord/status` – Status des Discord-Bots.
-- `POST /api/discord/message` – Sendet eine Nachricht an einen Kanal.
+- `GET /api/discord/status` – Status of the Discord bot.
+- `POST /api/discord/message` – Sends a message to a channel.
 
-Weitere Module (Auth, Commerce, Tickets, Integrationen) werden sukzessive auf Prisma-basierte Services migriert. Einstiegspunkte sind `src/api/routes` sowie die zugehörigen Controller.
+Additional modules (auth, commerce, tickets, integrations) are gradually migrating to Prisma-based services. The main entry points are `src/api/routes` and the corresponding controllers.
 
-## Discord-Bot
+## Discord Bot
 
-Der Bot startet derzeit über `src/bot/index.js` (Migration nach TypeScript ist in Arbeit) und nutzt gemeinsam genutzte Services. Kommandos und Events werden unter `src/bot/commands` bzw. `src/bot/events` verwaltet.
+The bot currently starts via `src/bot/index.js` (a TypeScript migration is in progress) and reuses shared services. Commands and events are managed under `src/bot/commands` and `src/bot/events`.
 
-## Prisma Schema & Datenmodelle
+## Prisma Schema & Data Models
 
-- Schema-Datei: `prisma/schema.prisma`
-- Standardmodelle: `User`, `Role`, `Project`, `Ticket` (erweiterbar)
-- Migrationen: `prisma/migrations/`
-- Seeds: `prisma/seed.ts` oder TypeScript-Dateien unter `src/seeds/`
+- Schema file: `prisma/schema.prisma`
+- Default models: `User`, `Role`, `Project`, `Ticket` (extensible)
+- Migrations: `prisma/migrations/`
+- Seeds: `prisma/seed.ts` or TypeScript files inside `src/seeds/`
 
-## Verzeichnisstruktur
+## Directory Structure
 
-Siehe [`docs/meta/folder-structure.md`](../meta/folder-structure.md) für eine vollständige Übersicht.
+Refer to [`docs/meta/folder-structure.md`](../meta/folder-structure.md) for a complete overview.
 
-## Weitere Ressourcen
+## Additional Resources
 
 - [Contributing Guide](../process/contributing.md)
-- [Migrationsfahrplan](../planning/todo.md)
-- [Architekturübersicht](../overview/architecture.md)
+- [Migration roadmap](../planning/todo.md)
+- [Architecture overview](../overview/architecture.md)


### PR DESCRIPTION
## Summary
- translate the top-level project documentation files to English
- update all guides, process notes, and planning documents under `docs/` to English wording while keeping the structure intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f995a9af58832caedc677b3de271d7